### PR TITLE
修改藍新金流API網址

### DIFF
--- a/lib/offsite_payments/integrations/spgateway.rb
+++ b/lib/offsite_payments/integrations/spgateway.rb
@@ -29,11 +29,11 @@ module OffsitePayments #:nodoc:
         mode = ActiveMerchant::Billing::Base.mode
         case mode
           when :production
-            'https://core.spgateway.com/MPG/mpg_gateway'
+            'https://core.newebpay.com/MPG/mpg_gateway'
           when :development
-            'https://ccore.spgateway.com/MPG/mpg_gateway'
+            'https://ccore.newebpay.com/MPG/mpg_gateway'
           when :test
-            'https://ccore.spgateway.com/MPG/mpg_gateway'
+            'https://ccore.newebpay.com/MPG/mpg_gateway'
           else
             raise StandardError, "Integration mode set to an invalid value: #{mode}"
         end


### PR DESCRIPTION
新金流API串接網域已全面更新為 newebpay.com

[API文件下載](https://www.newebpay.com/website/Page/content/download_api)
